### PR TITLE
Tournament Registrations | Players mongo implementation

### DIFF
--- a/backend/src/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers.ts
+++ b/backend/src/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers.ts
@@ -1,20 +1,19 @@
-import {AvailablePlayersForTournament} from '../../../core/application/command/AvailablePlayersForTournament';
-import {Player, Players} from '../../../core/application/command/Players';
-import {PlayerId} from '../../../../../shared/core/domain/PlayerId';
+import { AvailablePlayersForTournament } from '../../../core/application/command/AvailablePlayersForTournament';
+import { Player, Players } from '../../../core/application/command/Players';
+import { PlayerId } from '../../../../../shared/core/domain/PlayerId';
 import mongoose, { Schema } from 'mongoose';
 
 export class MongoPlayers implements AvailablePlayersForTournament, Players {
-
   async save(player: Player): Promise<void> {
     await MongoPlayer.findByIdAndUpdate(
-        {_id: player.playerId.raw},
-        {_id: player.playerId.raw},
-        {upsert: true, useFindAndModify: true},
+      { _id: player.playerId.raw },
+      { _id: player.playerId.raw },
+      { upsert: true, useFindAndModify: true },
     );
   }
 
   async canPlay(playerId: PlayerId): Promise<boolean> {
-    return await MongoPlayer.exists({_id: playerId.raw})
+    return await MongoPlayer.exists({ _id: playerId.raw });
   }
 }
 

--- a/backend/src/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers.ts
+++ b/backend/src/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers.ts
@@ -1,0 +1,33 @@
+import {AvailablePlayersForTournament} from '../../../core/application/command/AvailablePlayersForTournament';
+import {Player, Players} from '../../../core/application/command/Players';
+import {PlayerId} from '../../../../../shared/core/domain/PlayerId';
+import mongoose, { Schema } from 'mongoose';
+
+export class MongoPlayers implements AvailablePlayersForTournament, Players {
+
+  async save(player: Player): Promise<void> {
+    await MongoPlayer.findByIdAndUpdate(
+        {_id: player.playerId.raw},
+        {_id: player.playerId.raw},
+        {upsert: true, useFindAndModify: true},
+    );
+  }
+
+  async canPlay(playerId: PlayerId): Promise<boolean> {
+    return await MongoPlayer.exists({_id: playerId.raw})
+  }
+}
+
+type MongoPlayer = {
+  readonly _id: string;
+} & mongoose.Document;
+
+const PlayerSchema = new mongoose.Schema({
+  _id: Schema.Types.String,
+});
+
+const MongoPlayer = mongoose.model<MongoPlayer>('TournamentRegistrationsAvailablePlayers', PlayerSchema);
+
+function mongoDocumentToDomain(mongoDocument: MongoPlayer): PlayerId {
+  return PlayerId.from(mongoDocument._id);
+}

--- a/backend/test/modules/tournaments-registrations/infrastructure/repository/PlayersTestCases.ts
+++ b/backend/test/modules/tournaments-registrations/infrastructure/repository/PlayersTestCases.ts
@@ -2,8 +2,8 @@ import { DatabaseTestSupport } from '../../../../test-support/shared/infrastruct
 import { EntityIdGenerator } from '../../../../../src/shared/core/application/EntityIdGenerator';
 import { UuidEntityIdGenerator } from '../../../../../src/shared/infrastructure/core/application/UuidEntityIdGenerator';
 import { PlayerId } from '../../../../../src/shared/core/domain/PlayerId';
-import {Players} from "../../../../../src/modules/tournaments-registrations/core/application/command/Players";
-import {AvailablePlayersForTournament} from "../../../../../src/modules/tournaments-registrations/core/application/command/AvailablePlayersForTournament";
+import { Players } from '../../../../../src/modules/tournaments-registrations/core/application/command/Players';
+import { AvailablePlayersForTournament } from '../../../../../src/modules/tournaments-registrations/core/application/command/AvailablePlayersForTournament';
 
 export function PlayersTestCases(props: {
   name: string;
@@ -26,8 +26,8 @@ export function PlayersTestCases(props: {
       const playerId2 = PlayerId.from(entityIdGenerator.generate());
       const playerId3 = PlayerId.from(entityIdGenerator.generate());
 
-      await repository.save({playerId: playerId1});
-      await repository.save({playerId: playerId2});
+      await repository.save({ playerId: playerId1 });
+      await repository.save({ playerId: playerId2 });
 
       expect(await repository.canPlay(playerId1)).toBeTruthy();
       expect(await repository.canPlay(playerId2)).toBeTruthy();

--- a/backend/test/modules/tournaments-registrations/infrastructure/repository/PlayersTestCases.ts
+++ b/backend/test/modules/tournaments-registrations/infrastructure/repository/PlayersTestCases.ts
@@ -1,0 +1,45 @@
+import { DatabaseTestSupport } from '../../../../test-support/shared/infrastructure/DatabaseTestSupport';
+import { EntityIdGenerator } from '../../../../../src/shared/core/application/EntityIdGenerator';
+import { UuidEntityIdGenerator } from '../../../../../src/shared/infrastructure/core/application/UuidEntityIdGenerator';
+import { PlayerId } from '../../../../../src/shared/core/domain/PlayerId';
+import {Players} from "../../../../../src/modules/tournaments-registrations/core/application/command/Players";
+import {AvailablePlayersForTournament} from "../../../../../src/modules/tournaments-registrations/core/application/command/AvailablePlayersForTournament";
+
+export function PlayersTestCases(props: {
+  name: string;
+  repositoryFactory: () => Players & AvailablePlayersForTournament;
+  databaseTestSupport: DatabaseTestSupport;
+}): void {
+  return describe(props.name, () => {
+    const entityIdGenerator: EntityIdGenerator = new UuidEntityIdGenerator();
+    let repository: Players & AvailablePlayersForTournament;
+
+    beforeAll(async () => {
+      await props.databaseTestSupport.openConnection();
+      repository = props.repositoryFactory();
+    });
+    afterEach(async () => await props.databaseTestSupport.clearDatabase());
+    afterAll(async () => await props.databaseTestSupport.closeConnection());
+
+    test('canPlay returns true when given player was saved', async () => {
+      const playerId1 = PlayerId.from(entityIdGenerator.generate());
+      const playerId2 = PlayerId.from(entityIdGenerator.generate());
+      const playerId3 = PlayerId.from(entityIdGenerator.generate());
+
+      await repository.save({playerId: playerId1});
+      await repository.save({playerId: playerId2});
+
+      expect(await repository.canPlay(playerId1)).toBeTruthy();
+      expect(await repository.canPlay(playerId2)).toBeTruthy();
+      expect(await repository.canPlay(playerId3)).toBeFalsy();
+    });
+
+    test('canPlay returns false when given player was not saved', async () => {
+      const playerId1 = PlayerId.from(entityIdGenerator.generate());
+      const playerId2 = PlayerId.from(entityIdGenerator.generate());
+
+      expect(await repository.canPlay(playerId1)).toBeFalsy();
+      expect(await repository.canPlay(playerId2)).toBeFalsy();
+    });
+  });
+}

--- a/backend/test/modules/tournaments-registrations/infrastructure/repository/inmemory/InMemoryPlayers.spec.ts
+++ b/backend/test/modules/tournaments-registrations/infrastructure/repository/inmemory/InMemoryPlayers.spec.ts
@@ -1,0 +1,11 @@
+import { PlayersTestCases } from '../PlayersTestCases';
+import { InMemoryPlayers } from '../../../../../../src/modules/tournaments-registrations/infrastructure/repository/inmemory/InMemoryPlayers';
+import { InMemoryTestSupport } from '../../../../../test-support/shared/infrastructure/InMemoryTestSupport';
+
+describe('Players & AvailablePlayersForTournament', () => {
+  PlayersTestCases({
+    name: 'InMemory Implementation',
+    repositoryFactory: () => new InMemoryPlayers(),
+    databaseTestSupport: InMemoryTestSupport,
+  });
+});

--- a/backend/test/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers.mongo-spec.ts
+++ b/backend/test/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers.mongo-spec.ts
@@ -1,0 +1,11 @@
+import {MongoTestSupport} from "../../../../../test-support/shared/infrastructure/MongooseTestSupport";
+import {PlayersTestCases} from "../PlayersTestCases";
+import {MongoPlayers} from "../../../../../../src/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers";
+
+describe('Players & AvailablePlayersForTournament', () => {
+  PlayersTestCases({
+    name: 'MongoDb Implementation',
+    repositoryFactory: () => new MongoPlayers(),
+    databaseTestSupport: MongoTestSupport,
+  });
+});

--- a/backend/test/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers.mongo-spec.ts
+++ b/backend/test/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers.mongo-spec.ts
@@ -1,6 +1,6 @@
-import {MongoTestSupport} from "../../../../../test-support/shared/infrastructure/MongooseTestSupport";
-import {PlayersTestCases} from "../PlayersTestCases";
-import {MongoPlayers} from "../../../../../../src/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers";
+import { MongoTestSupport } from '../../../../../test-support/shared/infrastructure/MongooseTestSupport';
+import { PlayersTestCases } from '../PlayersTestCases';
+import { MongoPlayers } from '../../../../../../src/modules/tournaments-registrations/infrastructure/repository/mongo/MongoPlayers';
 
 describe('Players & AvailablePlayersForTournament', () => {
   PlayersTestCases({


### PR DESCRIPTION
Gracze w module turnieju (możliwi do zapisu) nie byli zapisywani w monogo, a jedynie w InMemory.
Obecnie kiedy zdarzy się event PlayerProfileCreated moduł TournamentRegistrations zapisuje własną lokalną kopię profilu (jedynie id). Tak, aby potem sprawdzać, czy zapisywany gracz rzeczywiście istnieje (poprzez AvailablePlayers.canPlay) bez potrzeby komunikacji z modułem PlayerProfiles. 
Wcześniej była implementacja tylko InMemory, więc przy wyłączaniu/włączaniu aplikacji, która korzysta z Mongo istniałyby profile w PlayerProfiles, ale moduł TournamentRegistrations by o tym nie wiedział.